### PR TITLE
Fixed how default tags are specified and merged with those injected by Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - Added tags specification for resources managed by terraform configuration [#4](https://github.com/unity-sds/unity-ui-infra/issues/4)
+- Fixed how tags are specified to resolve issue when Terraform code is executed [#9](https://github.com/unity-sds/unity-ui-infra/issues/9)
 
 ## [0.1.0] 2024-04-15
 

--- a/terraform-unity-ui/alb.tf
+++ b/terraform-unity-ui/alb.tf
@@ -7,6 +7,7 @@ resource "aws_lb" "main" {
   enable_deletion_protection = false
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 }
@@ -29,6 +30,7 @@ resource "aws_alb_target_group" "app" {
   }
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 }
@@ -39,6 +41,7 @@ resource "aws_alb_listener" "front_end" {
   protocol = "HTTP"
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 

--- a/terraform-unity-ui/ecs.tf
+++ b/terraform-unity-ui/ecs.tf
@@ -2,6 +2,7 @@ resource "aws_ecs_cluster" "main" {
   name = "${var.project}-${var.venue}-dashboard-cluster"
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 }
@@ -75,6 +76,7 @@ resource "aws_ecs_task_definition" "app" {
   )
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 }
@@ -87,6 +89,7 @@ resource "aws_ecs_service" "main" {
   launch_type     = "FARGATE"
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 

--- a/terraform-unity-ui/iam.tf
+++ b/terraform-unity-ui/iam.tf
@@ -2,6 +2,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
   name = "${var.project}-${var.venue}-dashboard-ecs_task_execution_role"
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 

--- a/terraform-unity-ui/security.tf
+++ b/terraform-unity-ui/security.tf
@@ -4,6 +4,7 @@ resource "aws_security_group" "ecs_sg" {
   vpc_id = data.aws_ssm_parameter.vpc_id.value
   tags = merge(
     var.tags,
+    var.default_tags,
     {},
   )
 

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -32,6 +32,11 @@ variable "project" {
 variable "tags" {
   description = "Tags to be applied to Unity UI resources that support tags"
   type        = map(string)
+}
+
+variable "default_tags" {
+  description = ""
+  type        = map(string)
   default     = {
     Venue = "dev",
     ServiceArea = "uiux",


### PR DESCRIPTION
## Purpose

This PR contains the changes needed to fix an issue with tags not being set when the Unity UI Terraform configuration is executed by the management console.

## Proposed Changes
- [FIX] Created a "default_tags" Terraform variable which is merged with the auto injected set of tags when Terraform resources are created. In this fashion, any key in the default_tags var will overwrite those injected by marketplace.

## Issues
- #9 

## Testing
- Cannot be tested locally, needs to be published so that tests against Marketplace can be executed.