### PR TITLE
Updated cost tags specifications

### DIFF
--- a/terraform-unity-ui/alb.tf
+++ b/terraform-unity-ui/alb.tf
@@ -7,8 +7,7 @@ resource "aws_lb" "main" {
   enable_deletion_protection = false
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 }
 
@@ -30,8 +29,7 @@ resource "aws_alb_target_group" "app" {
   }
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 }
 
@@ -41,8 +39,7 @@ resource "aws_alb_listener" "front_end" {
   protocol = "HTTP"
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 
   default_action {

--- a/terraform-unity-ui/alb.tf
+++ b/terraform-unity-ui/alb.tf
@@ -7,7 +7,11 @@ resource "aws_lb" "main" {
   enable_deletion_protection = false
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 }
 
@@ -30,7 +34,11 @@ resource "aws_alb_target_group" "app" {
 
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 
 }
@@ -42,7 +50,11 @@ resource "aws_alb_listener" "front_end" {
 
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 
   default_action {

--- a/terraform-unity-ui/ecs.tf
+++ b/terraform-unity-ui/ecs.tf
@@ -2,8 +2,7 @@ resource "aws_ecs_cluster" "main" {
   name = "${var.project}-${var.venue}-dashboard-cluster"
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 }
 
@@ -76,8 +75,7 @@ resource "aws_ecs_task_definition" "app" {
   )
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 }
 
@@ -89,8 +87,7 @@ resource "aws_ecs_service" "main" {
   launch_type     = "FARGATE"
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 
   network_configuration {

--- a/terraform-unity-ui/ecs.tf
+++ b/terraform-unity-ui/ecs.tf
@@ -2,7 +2,11 @@ resource "aws_ecs_cluster" "main" {
   name = "${var.project}-${var.venue}-dashboard-cluster"
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 }
 
@@ -75,7 +79,11 @@ resource "aws_ecs_task_definition" "app" {
   )
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 }
 
@@ -85,10 +93,14 @@ resource "aws_ecs_service" "main" {
   task_definition = aws_ecs_task_definition.app.arn
   desired_count   = var.app_count
   launch_type     = "FARGATE"
-  
+
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 
   network_configuration {

--- a/terraform-unity-ui/iam.tf
+++ b/terraform-unity-ui/iam.tf
@@ -2,8 +2,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
   name = "${var.project}-${var.venue}-dashboard-ecs_task_execution_role"
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 
   assume_role_policy = jsonencode({

--- a/terraform-unity-ui/iam.tf
+++ b/terraform-unity-ui/iam.tf
@@ -1,9 +1,13 @@
 resource "aws_iam_role" "ecs_task_execution_role" {
   name = "${var.project}-${var.venue}-dashboard-ecs_task_execution_role"
-  
+
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 
   assume_role_policy = jsonencode({

--- a/terraform-unity-ui/security.tf
+++ b/terraform-unity-ui/security.tf
@@ -4,8 +4,7 @@ resource "aws_security_group" "ecs_sg" {
   vpc_id = data.aws_ssm_parameter.vpc_id.value
   tags = merge(
     var.tags,
-    var.default_tags,
-    {},
+    var.additional_tags
   )
 
   // Inbound rules

--- a/terraform-unity-ui/security.tf
+++ b/terraform-unity-ui/security.tf
@@ -2,10 +2,14 @@ resource "aws_security_group" "ecs_sg" {
   name = "${var.project}-${var.venue}-dashboard-ecs-sg"
   description = "Security group for the dashboard ECS Service"
   vpc_id = data.aws_ssm_parameter.vpc_id.value
-  
+
   tags = merge(
     var.tags,
-    var.additional_tags
+    var.additional_tags,
+    {
+      Venue = var.venue
+      Proj = var.project
+    }
   )
 
   // Inbound rules

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -49,6 +49,6 @@ variable "additional_tags" {
 
 // Injected by Marketplace
 variable "venue" {
-  description = "The MCP venue in which the cluster will be deployed (dev, test, prod)"
+  description = "The project venue deployment in which the UI service will be deployed"
   type        = string
 }

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -42,7 +42,7 @@ variable "additional_tags" {
     ServiceArea = "uiux"
     CapVersion = "0.8.0"
     Component = "navbar"
-    Proj = "Unity"
+    Proj = "unity"
     CreatedBy = "uiux"
     Env = "dev"
     Stack = "ui"

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -38,11 +38,9 @@ variable "additional_tags" {
   description = "Additional Resource Tags"
   type        = map(string)
   default     = {
-    Venue = "dev"
     ServiceArea = "uiux"
     CapVersion = "0.8.0"
     Component = "navbar"
-    Proj = "unity"
     CreatedBy = "uiux"
     Env = "dev"
     Stack = "ui"

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -34,18 +34,18 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "default_tags" {
-  description = ""
+variable "additional_tags" {
+  description = "Additional Resource Tags"
   type        = map(string)
   default     = {
     Venue = "dev"
     ServiceArea = "uiux"
     CapVersion = "0.8.0"
-    Component = "Navbar"
+    Component = "navbar"
     Proj = "Unity"
     CreatedBy = "uiux"
     Env = "dev"
-    Stack = "UI"
+    Stack = "ui"
   }
 }
 


### PR DESCRIPTION
## Purpose

This PR addresses the need to revert costs tags to the original setup after extensive testing with MC.

## Proposed Changes
- [CHANGE] Cost tags to use original specification that was implemented after it was determined that the newest version of MC doesn't experience the issues we were encountering with cost tags not being set.

## Issues

Fixes #9 

## Testing

Tested with Galen using a custom project venue he had set up.
