### PR TITLE
Updated proxy service name to be `ui` instead of `dashboard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added tags specification for resources managed by terraform configuration [#4](https://github.com/unity-sds/unity-ui-infra/issues/4)
 - Fixed how tags are specified to resolve issue when Terraform code is executed [#9](https://github.com/unity-sds/unity-ui-infra/issues/9)
+- Updated proxy configuration. Our application is now accessible using the term `ui` instead of `dashboard` [#15](https://github.com/unity-sds/unity-ui-infra/issues/15)
 
 ## [0.1.0] 2024-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tags specification for resources managed by terraform configuration [#4](https://github.com/unity-sds/unity-ui-infra/issues/4)
 - Fixed how tags are specified to resolve issue when Terraform code is executed [#9](https://github.com/unity-sds/unity-ui-infra/issues/9)
 - Updated proxy configuration. Our application is now accessible using the term `ui` instead of `dashboard` [#15](https://github.com/unity-sds/unity-ui-infra/issues/15)
+- Updated terraform configurations so they use the term `ui` instead of `dashboard` [#15](https://github.com/unity-sds/unity-ui-infra/issues/15)
 
 ## [0.1.0] 2024-04-15
 

--- a/terraform-unity-ui/alb.tf
+++ b/terraform-unity-ui/alb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "main" {
-  name = "${var.project}-${var.venue}-dashboard-lb"
+  name = "${var.project}-${var.venue}-ui-lb"
   internal = false
   load_balancer_type = "application"
   subnets = local.public_subnet_ids
@@ -16,7 +16,7 @@ resource "aws_lb" "main" {
 }
 
 resource "aws_alb_target_group" "app" {
-  name        = "${var.project}-${var.venue}-dashboard-tg"
+  name        = "${var.project}-${var.venue}-ui-tg"
   port        = 8080
   protocol    = "HTTP"
   vpc_id      = data.aws_ssm_parameter.vpc_id.value

--- a/terraform-unity-ui/ecs.tf
+++ b/terraform-unity-ui/ecs.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "main" {
-  name = "${var.project}-${var.venue}-dashboard-cluster"
+  name = "${var.project}-${var.venue}-ui-cluster"
   tags = merge(
     var.tags,
     var.additional_tags,
@@ -11,7 +11,7 @@ resource "aws_ecs_cluster" "main" {
 }
 
 resource "aws_ecs_task_definition" "app" {
-  family = "${var.project}-${var.venue}-dashboard-app"
+  family = "${var.project}-${var.venue}-ui-app"
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
   network_mode = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -20,7 +20,7 @@ resource "aws_ecs_task_definition" "app" {
   container_definitions = jsonencode(
     [
       {
-        name = "dashboard"
+        name = "ui"
         image = var.app_image
         environment = [
           {
@@ -41,11 +41,11 @@ resource "aws_ecs_task_definition" "app" {
           },
           {
             name = "ENV_UNITY_UI_BASE_PATH"
-            value = "/${var.project}/${var.venue}/dashboard"
+            value = "/${var.project}/${var.venue}/ui"
           },
           {
             name = "ENV_UNITY_UI_AUTH_OAUTH_REDIRECT_URI"
-            value = "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/dashboard"
+            value = "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/ui"
           },
           {
             name = "ENV_UNITY_UI_AUTH_OAUTH_LOGOUT_ENDPOINT"
@@ -88,7 +88,7 @@ resource "aws_ecs_task_definition" "app" {
 }
 
 resource "aws_ecs_service" "main" {
-  name            = "${var.project}-${var.venue}-dashboard-service"
+  name            = "${var.project}-${var.venue}-ui-service"
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.app.arn
   desired_count   = var.app_count
@@ -111,7 +111,7 @@ resource "aws_ecs_service" "main" {
 
   load_balancer {
     target_group_arn = aws_alb_target_group.app.id
-    container_name = "dashboard"
+    container_name = "ui"
     container_port = 8080
   }
 

--- a/terraform-unity-ui/iam.tf
+++ b/terraform-unity-ui/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name = "${var.project}-${var.venue}-dashboard-ecs_task_execution_role"
+  name = "${var.project}-${var.venue}-ui-ecs_task_execution_role"
 
   tags = merge(
     var.tags,

--- a/terraform-unity-ui/proxy.tf
+++ b/terraform-unity-ui/proxy.tf
@@ -1,10 +1,10 @@
-resource "aws_ssm_parameter" "uiux_dashboard_proxy_config" {
+resource "aws_ssm_parameter" "uiux_ui_proxy_config" {
   depends_on = [ aws_lb.main ]
-  name       = "/unity/${var.project}/${var.venue}/cs/management/proxy/configurations/010-uiux-dashboard"
+  name       = "/unity/${var.project}/${var.venue}/cs/management/proxy/configurations/010-uiux-ui"
   type       = "String"
   value      = <<-EOT
 
-    <location "/${var.project}/${var.venue}/dashboard">
+    <location "/${var.project}/${var.venue}/ui">
       ProxyHTMLEnable on
       RequestHeader unset Accept-Encoding
       ProxyHTMLCHarsetOut *
@@ -13,19 +13,19 @@ resource "aws_ssm_parameter" "uiux_dashboard_proxy_config" {
       Header always set Strict-Transport-Security "max-age=63072000"
       ProxyPass "http://${aws_lb.main.dns_name}:8080/" retry=5 disablereuse=On
       ProxyPassReverse "http://${aws_lb.main.dns_name}:8080/"
-      ProxyHTMLURLMap / /${var.project}/${var.venue}/dashboard/
+      ProxyHTMLURLMap / /${var.project}/${var.venue}/ui/
     </location>
 
 EOT
 }
 
 resource "aws_lambda_invocation" "proxy_lambda_invocation" {
-  depends_on = [ aws_lb.main, aws_ssm_parameter.uiux_dashboard_proxy_config ]
+  depends_on = [ aws_lb.main, aws_ssm_parameter.uiux_ui_proxy_config ]
   function_name = "${var.project}-${var.venue}-httpdproxymanagement"
   input = ""
   triggers = {
     redeployment = sha1(jsonencode([
-      aws_ssm_parameter.uiux_dashboard_proxy_config
+      aws_ssm_parameter.uiux_ui_proxy_config
     ]))
   }
 }

--- a/terraform-unity-ui/security.tf
+++ b/terraform-unity-ui/security.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "ecs_sg" {
-  name = "${var.project}-${var.venue}-dashboard-ecs-sg"
-  description = "Security group for the dashboard ECS Service"
+  name = "${var.project}-${var.venue}-ui-ecs-sg"
+  description = "Security group for the UI ECS Service"
   vpc_id = data.aws_ssm_parameter.vpc_id.value
 
   tags = merge(


### PR DESCRIPTION
## Purpose

Updated proxy service name to be `ui` instead of `dashboard`.  So, one would visit the following URL to access the application:

```
http://www.<environment>.mdps.mcp.nasa.gov:4443/<project>/<venue>/ui
```

## Proposed Changes
- [CHANGE] Application is now accessible at the proxy name `ui` instead of `dashboard`.
- [CHANGE] Our AWS resources managed by terraform also no longer use the name `dashboard` and use `ui` instead.

## Issues
Fixes #15

## Testing

Tested locally and by doing manual deployments of our terraform to Unity-Venue-Dev.